### PR TITLE
DTSPO-189 Sync health path override from frontdoor to fe ag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -67,7 +67,7 @@ resource "azurerm_application_gateway" "ag" {
     for_each = [for app in var.frontends : {
       name = app.name
       host = app.custom_domain
-      path = lookup(app, "health_path_override", "/health/liveness")
+      path = lookup(app, "health_path", "/health/liveness")
     }]
 
     content {


### PR DESCRIPTION
Frontdoor health path override uses `health_path`

https://github.com/hmcts/terraform-module-frontdoor/blob/144394a5f85a0240f5c791e27ec92838bf69ee01/frontdoor.tf#L96

It's currently used in a few places by applications not backed by application gateway.
So that means we have to sync them otherwise we need to define the 2 override properties which is unacceptable.

Unfortunately this means the field is difference across the frontend and backend app gateways, but I think we can live with it unless we want to update them all to be the same?