### PR TITLE
DTSPO-3187 - Allow creation of parallel resources with new names

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ No requirements.
 |------|-------------|------|---------|:--------:|
 | common\_tags | Common Tags | `map(string)` | n/a | yes |
 | destinations | List of IP addresses to direct traffic to | `list(string)` | n/a | yes |
+| enable\_multiple\_availability_zones | Create application gateway with multiple availability zones | `boolean` | false | no |
 | env | environment, will be used in resource names and for looking up the vnet details | `any` | n/a | yes |
 | frontends | n/a | `list(any)` | n/a | yes |
 | location | location to deploy resources to | `any` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ No requirements.
 | oms\_env | Name of the enviornment for log analytics workspace | `any` | n/a | yes |
 | private\_ip\_address | IP address to allocate staticly to app gateway, must be in the subnet for the env | `any` | n/a | yes |
 | project | Name of the project | `string` | n/a | yes |
+| resource_prefix | Resource name prefix | `string` | n/a | no |
 | subscription | subscription, will be used for looking up the keyvault details | `any` | n/a | yes |
 | vnet\_name | Name of the Virtual Network | `string` | n/a | yes |
 | vnet\_rg | Name of the virtual Network resource group | `string` | n/a | yes |

--- a/config.tf
+++ b/config.tf
@@ -8,7 +8,7 @@ data "azurerm_subnet" "app_gw" {
 resource "azurerm_public_ip" "app_gw" {
   count = length(var.frontends) != 0 ? 1 : 0
 
-  name                = "aks-fe-appgw-${var.env}-pip"
+  name                = (var.create_new_agw == true) ? "aks-frontend-appgw-${var.env}-pip" : "aks-fe-appgw-${var.env}-pip"
   location            = var.location
   resource_group_name = var.vnet_rg
   sku                 = "Standard"

--- a/config.tf
+++ b/config.tf
@@ -8,7 +8,7 @@ data "azurerm_subnet" "app_gw" {
 resource "azurerm_public_ip" "app_gw" {
   count = length(var.frontends) != 0 ? 1 : 0
 
-  name                = (var.resource_prefix != null) ? "${var.resource_prefix}-aks-fe-appgw-${var.env}-pip" : "aks-fe-appgw-${var.env}-pip"
+  name                = "${local.resource_prefix}aks-fe-appgw-${var.env}-pip"
   location            = var.location
   resource_group_name = var.vnet_rg
   sku                 = "Standard"

--- a/config.tf
+++ b/config.tf
@@ -8,7 +8,7 @@ data "azurerm_subnet" "app_gw" {
 resource "azurerm_public_ip" "app_gw" {
   count = length(var.frontends) != 0 ? 1 : 0
 
-  name                = (var.create_new_agw == true) ? "aks-frontend-appgw-${var.env}-pip" : "aks-fe-appgw-${var.env}-pip"
+  name                = (var.resource_prefix != null) ? "${var.resource_prefix}-aks-fe-appgw-${var.env}-pip" : "aks-fe-appgw-${var.env}-pip"
   location            = var.location
   resource_group_name = var.vnet_rg
   sku                 = "Standard"

--- a/main.tf
+++ b/main.tf
@@ -10,10 +10,11 @@
 
 locals {
   x_fwded_proto_ruleset = "x_fwded_proto"
+  resource_prefix = var.resource_prefix != null ? "${var.resource_prefix}-" : ""
 }
 
 resource "azurerm_application_gateway" "ag" {
-  name                = (var.resource_prefix != null) ? "${var.resource_prefix}-aks-fe-${format("%02d", count.index)}-${var.env}-agw" : "aks-fe-${format("%02d", count.index)}-${var.env}-agw"
+  name                = "${local.resource_prefix}aks-fe-${format("%02d", count.index)}-${var.env}-agw"
   resource_group_name = var.vnet_rg
   location            = var.location
   tags                = var.common_tags

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ locals {
 }
 
 resource "azurerm_application_gateway" "ag" {
-  name                = "aks-fe-${format("%02d", count.index)}-${var.env}-agw"
+  name                = (var.create_new_agw == true) ? "aks-frontend-${format("%02d", count.index)}-${var.env}-agw" : "aks-fe-${format("%02d", count.index)}-${var.env}-agw"
   resource_group_name = var.vnet_rg
   location            = var.location
   tags                = var.common_tags

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ locals {
 }
 
 resource "azurerm_application_gateway" "ag" {
-  name                = (var.create_new_agw == true) ? "aks-frontend-${format("%02d", count.index)}-${var.env}-agw" : "aks-fe-${format("%02d", count.index)}-${var.env}-agw"
+  name                = (var.resource_prefix != null) ? "${var.resource_prefix}-aks-fe-${format("%02d", count.index)}-${var.env}-agw" : "aks-fe-${format("%02d", count.index)}-${var.env}-agw"
   resource_group_name = var.vnet_rg
   location            = var.location
   tags                = var.common_tags

--- a/variables.tf
+++ b/variables.tf
@@ -62,7 +62,7 @@ variable "enable_multiple_availability_zones" {
   default = false
 }
 
-variable "create_new_agw" {
-  description = "Create resources with new naming convention"
-  default = false
+variable "resource_prefix" {
+  description = "Optional name prefix for resources"
+  default = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -64,5 +64,6 @@ variable "enable_multiple_availability_zones" {
 
 variable "resource_prefix" {
   description = "Optional name prefix for resources"
-  default = ""
+  type        = string
+  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -61,3 +61,8 @@ variable "log_analytics_workspace_id" {
 variable "enable_multiple_availability_zones" {
   default = false
 }
+
+variable "create_new_agw" {
+  description = "Create resources with new naming convention"
+  default = false
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-3187


### Change description ###
To rollout multi-az AGW in CFT, we are adopting a side-by-side deployment approach whereby new AGW with different naming coexists with the live AG prior to switch over.  

The module is being updated to support creation of resources with a different naming convention to the existing.  Existing resources are left untouched.

Confirmation of no changes to existing appgw resources:
[sds-azure-platform-terraform ](https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=215055&view=results)plan
[cft-azure-platform-terraform](https://dev.azure.com/hmcts/CNP/_build/results?buildId=215057&view=results) plan


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
