### PR TITLE
Increase backend health beyond default liveness

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -73,7 +73,7 @@ resource "azurerm_application_gateway" "ag" {
     }]
 
     content {
-      interval            = 10
+      interval            = 20
       name                = probe.value.name
       host                = probe.value.host
       path                = probe.value.path


### PR DESCRIPTION
Current default application liveness is 15 seconds, having a value less than that doesn't make sense as appgw will remove entire cluster from load balancing while 1 pod is faulty.  (even before k8s acts to remove)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
